### PR TITLE
feat(contracts): require schemaVersion, consistent userId validation

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -18,6 +18,7 @@ import {
   OrderMessageSchema,   // Zod schema (runtime validation)
   ResultMessage,
   ResultMessageSchema,
+  SCHEMA_VERSION,
 } from "@qlibin/tg-assistant-contracts";
 
 // Type-safe message construction
@@ -27,6 +28,7 @@ const order: OrderMessage = {
   payload: { url: "https://example.com" },
   userId: "12345",
   timestamp: new Date().toISOString(),
+  schemaVersion: SCHEMA_VERSION,
 };
 
 // Runtime validation (e.g., when consuming from SQS)
@@ -45,17 +47,17 @@ if (!result.success) {
 
 Messages sent to the Order Queue for worker processing.
 
-**Required fields:** `orderId`, `taskType`, `payload`, `userId`, `timestamp`
+**Required fields:** `orderId`, `taskType`, `payload`, `userId`, `timestamp`, `schemaVersion`
 
-**Optional fields:** `priority`, `retryCount`, `deduplicationId`, `correlationId`, `schemaVersion`
+**Optional fields:** `priority`, `retryCount`, `deduplicationId`, `correlationId`
 
 ### ResultMessage
 
 Processing results sent to the Result Queue for feedback handling.
 
-**Required fields:** `orderId`, `taskType`, `status`, `result`, `processingTime`, `timestamp`, `userId`
+**Required fields:** `orderId`, `taskType`, `status`, `result`, `processingTime`, `timestamp`, `userId`, `schemaVersion`
 
-**Optional fields:** `correlationId`, `followUpAction`, `priority`, `retryCount`, `cost`, `queueMetrics`, `schemaVersion`
+**Optional fields:** `correlationId`, `followUpAction`, `priority`, `retryCount`, `cost`, `queueMetrics`
 
 ### Shared enums
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlibin/tg-assistant-contracts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared message schemas and TypeScript types for tg-assistant SQS queues",
   "type": "module",
   "main": "dist/index.js",

--- a/contracts/src/schemas/order-message.ts
+++ b/contracts/src/schemas/order-message.ts
@@ -24,7 +24,7 @@ export const OrderMessageSchema = z.object({
   retryCount: z.number().int().min(0).max(3).optional(),
   deduplicationId: z.string().max(128).optional(),
   correlationId: z.string().optional(),
-  schemaVersion: z.literal(SCHEMA_VERSION).optional(),
+  schemaVersion: z.literal(SCHEMA_VERSION),
 });
 
 export type OrderMessage = z.infer<typeof OrderMessageSchema>;

--- a/contracts/src/schemas/result-message.ts
+++ b/contracts/src/schemas/result-message.ts
@@ -49,13 +49,13 @@ export const ResultMessageSchema = z.object({
   result: ResultDataSchema,
   processingTime: z.number(),
   timestamp: z.string().datetime(),
-  userId: z.string(),
+  userId: z.string().min(1),
   followUpAction: FollowUpActionSchema.optional(),
   priority: PrioritySchema.optional(),
   retryCount: z.number().int().min(0).max(3).optional(),
   cost: z.number().min(0).optional(),
   queueMetrics: QueueMetricsSchema.optional(),
-  schemaVersion: z.literal(SCHEMA_VERSION).optional(),
+  schemaVersion: z.literal(SCHEMA_VERSION),
 });
 
 export type ResultMessage = z.infer<typeof ResultMessageSchema>;

--- a/contracts/test/schemas.test.ts
+++ b/contracts/test/schemas.test.ts
@@ -21,6 +21,7 @@ function validOrderMessage(): OrderMessage {
     payload: { url: "https://example.com" },
     userId: "12345",
     timestamp: new Date().toISOString(),
+    schemaVersion: SCHEMA_VERSION,
   };
 }
 
@@ -33,6 +34,7 @@ function validResultMessage(): ResultMessage {
     processingTime: 1500,
     timestamp: new Date().toISOString(),
     userId: "12345",
+    schemaVersion: SCHEMA_VERSION,
   };
 }
 
@@ -68,6 +70,13 @@ describe("OrderMessageSchema", () => {
 
   it("rejects missing required fields", () => {
     const result = OrderMessageSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing schemaVersion", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { schemaVersion, ...msg } = validOrderMessage();
+    const result = OrderMessageSchema.safeParse(msg);
     expect(result.success).toBe(false);
   });
 
@@ -176,6 +185,19 @@ describe("ResultMessageSchema", () => {
 
   it("rejects missing required fields", () => {
     const result = ResultMessageSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty userId", () => {
+    const msg = { ...validResultMessage(), userId: "" };
+    const result = ResultMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing schemaVersion", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { schemaVersion, ...msg } = validResultMessage();
+    const result = ResultMessageSchema.safeParse(msg);
     expect(result.success).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- Make `schemaVersion` required in both `OrderMessage` and `ResultMessage` — no existing producers/consumers, so this enforces good habits from day one
- Add `.min(1)` to `ResultMessage.userId` for consistency with `OrderMessage` (prevents empty user IDs)
- Bump version to `1.1.0`

## Test plan
- [x] 33 tests pass (3 new: missing schemaVersion rejection for both schemas, empty userId rejection for ResultMessage)
- [x] 100% coverage
- [x] `npm run validate` green for both contracts and infrastructure
- [ ] After merge, tag `contracts-v1.1.0` and push to trigger publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)