### PR TITLE
refactor: externalize sensitive config from cdk.json to env vars

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,10 @@ env:
   AWS_REGION: eu-central-1
   ENV_NAME: dev
   AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+  CERTIFICATE_ARN: ${{ vars.CERTIFICATE_ARN }}
+  HOSTED_ZONE_ID: ${{ vars.HOSTED_ZONE_ID }}
+  HOSTED_ZONE_NAME: ${{ vars.HOSTED_ZONE_NAME }}
+  DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
   RUN_BOOTSTRAP: ${{ vars.RUN_BOOTSTRAP || 'false' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ env:
   AWS_REGION: eu-central-1
   ENV_NAME: dev
   AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+  CERTIFICATE_ARN: ${{ vars.CERTIFICATE_ARN }}
+  HOSTED_ZONE_ID: ${{ vars.HOSTED_ZONE_ID }}
+  HOSTED_ZONE_NAME: ${{ vars.HOSTED_ZONE_NAME }}
+  DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
 
 jobs:
   validate-contracts:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,19 @@ All queues encrypted with KMS key (rotation enabled). CloudWatch alarms monitor 
 
 ### Environment Configuration
 
-Defined in `infrastructure/cdk.json` context. Environments: `dev`, `test`, `prod`. Stack names follow pattern: `DualQueueMessageStack-{env}`. Resource names: `{project}-{env}-{purpose}`.
+Environments (`dev`, `test`, `prod`) are defined in `infrastructure/cdk.json` context with non-sensitive config (region, envName, tags). Stack names follow pattern: `DualQueueMessageStack-{env}`. Resource names: `{project}-{env}-{purpose}`.
+
+**Environment variables** (required for CDK synth/diff/deploy):
+
+| Variable | Required | Source (CI/CD) | Purpose |
+|---|---|---|---|
+| `AWS_ACCOUNT_ID` | Yes | GH Variable | AWS account for stack deployment |
+| `CERTIFICATE_ARN` | No | GH Variable | ACM certificate for custom domain |
+| `HOSTED_ZONE_ID` | No | GH Variable | Route 53 hosted zone ID |
+| `HOSTED_ZONE_NAME` | No | GH Variable | Route 53 zone name |
+| `DOMAIN_NAME` | No | GH Variable | Custom domain name |
+
+Domain-related variables are optional — the ApiGateway stack is only created when all four are provided. For local development, copy `infrastructure/.env.example` to `infrastructure/.env` and fill in values.
 
 SSM parameters exported under `/automation/{environment}/...`.
 

--- a/infrastructure/.env.example
+++ b/infrastructure/.env.example
@@ -1,0 +1,8 @@
+# Required: AWS Account ID
+AWS_ACCOUNT_ID=
+
+# Optional: Domain configuration (needed for ApiGateway stack)
+CERTIFICATE_ARN=
+HOSTED_ZONE_ID=
+HOSTED_ZONE_NAME=
+DOMAIN_NAME=

--- a/infrastructure/bin/tg-assistant-infra.ts
+++ b/infrastructure/bin/tg-assistant-infra.ts
@@ -5,14 +5,9 @@ import { SQSStack } from "../lib/sqs-stack.js";
 import { ApiGatewayStack } from "../lib/api-gateway-stack.js";
 
 interface EnvConfig {
-  account: string;
   region: string;
   envName: string;
   tags?: Record<string, string>;
-  certificateArn?: string;
-  hostedZoneId?: string;
-  hostedZoneName?: string;
-  domainName?: string;
   existingDomainRegionalDomainName?: string;
   existingDomainRegionalHostedZoneId?: string;
 }
@@ -46,16 +41,23 @@ if (!envCfg) {
   );
 }
 
-// Optional account sanity check if AWS_ACCOUNT_ID is provided in environment
-const providedAccountId = process.env.AWS_ACCOUNT_ID;
-if (providedAccountId && providedAccountId !== envCfg.account) {
+// AWS Account ID: required from environment variable
+const account = process.env.AWS_ACCOUNT_ID;
+if (!account) {
   throw new Error(
-    `AWS account mismatch: AWS_ACCOUNT_ID=${providedAccountId} does not match CDK context account=${envCfg.account} for environment '${resolvedEnvName}'.`,
+    "AWS_ACCOUNT_ID environment variable is required. " +
+      "Set it in your shell or .env file for local development.",
   );
 }
 
+// Domain configuration: from environment variables (optional — ApiGateway stack only created when all present)
+const certificateArn = process.env.CERTIFICATE_ARN;
+const hostedZoneId = process.env.HOSTED_ZONE_ID;
+const hostedZoneName = process.env.HOSTED_ZONE_NAME;
+const domainName = process.env.DOMAIN_NAME;
+
 const sqsStack = new SQSStack(app, `DualQueueMessageStack-${envCfg.envName}`, {
-  env: { account: envCfg.account, region: envCfg.region },
+  env: { account, region: envCfg.region },
   description: `Dual SQS queues for TG Assistant (${envCfg.envName})`,
   environment: envCfg.envName,
   projectName: "tg-assistant",
@@ -65,25 +67,20 @@ const sqsStack = new SQSStack(app, `DualQueueMessageStack-${envCfg.envName}`, {
 cdk.Tags.of(sqsStack).add("app", "telegram-webhook");
 cdk.Tags.of(sqsStack).add("env", envCfg.envName);
 
-// API Gateway Stack (only if configuration is available)
-if (
-  envCfg.certificateArn &&
-  envCfg.hostedZoneId &&
-  envCfg.hostedZoneName &&
-  envCfg.domainName
-) {
+// API Gateway Stack (only if domain configuration is available via env vars)
+if (certificateArn && hostedZoneId && hostedZoneName && domainName) {
   const apiGatewayStack = new ApiGatewayStack(
     app,
     `ApiGatewayStack-${envCfg.envName}`,
     {
-      env: { account: envCfg.account, region: envCfg.region },
+      env: { account, region: envCfg.region },
       description: `API Gateway for TG Assistant (${envCfg.envName})`,
       environment: envCfg.envName,
       projectName: "tg-assistant",
-      certificateArn: envCfg.certificateArn,
-      hostedZoneId: envCfg.hostedZoneId,
-      hostedZoneName: envCfg.hostedZoneName,
-      domainName: envCfg.domainName,
+      certificateArn,
+      hostedZoneId,
+      hostedZoneName,
+      domainName,
       basePath: envCfg.envName,
       existingDomainRegionalDomainName: envCfg.existingDomainRegionalDomainName,
       existingDomainRegionalHostedZoneId:

--- a/infrastructure/cdk.json
+++ b/infrastructure/cdk.json
@@ -3,43 +3,28 @@
   "context": {
     "environments": {
       "dev": {
-        "account": "182399716679",
         "region": "eu-central-1",
         "envName": "dev",
         "tags": {
           "app": "telegram-assistant-infra",
           "env": "dev"
-        },
-        "certificateArn": "arn:aws:acm:eu-central-1:182399716679:certificate/e3271269-1fb8-4ac5-aaaa-ff585845602c",
-        "hostedZoneId": "Z0063833342G11THSVYEP",
-        "hostedZoneName": "qlibin.com",
-        "domainName": "tg.qlibin.com"
+        }
       },
       "test": {
-        "account": "182399716679",
         "region": "eu-central-1",
         "envName": "test",
         "tags": {
           "app": "telegram-assistant-infra",
           "env": "test"
-        },
-        "certificateArn": "arn:aws:acm:eu-central-1:182399716679:certificate/e3271269-1fb8-4ac5-aaaa-ff585845602c",
-        "hostedZoneId": "Z0063833342G11THSVYEP",
-        "hostedZoneName": "qlibin.com",
-        "domainName": "tg.qlibin.com"
+        }
       },
       "prod": {
-        "account": "182399716679",
         "region": "eu-central-1",
         "envName": "prod",
         "tags": {
           "app": "telegram-assistant-infra",
           "env": "prod"
-        },
-        "certificateArn": "arn:aws:acm:eu-central-1:182399716679:certificate/e3271269-1fb8-4ac5-aaaa-ff585845602c",
-        "hostedZoneId": "Z0063833342G11THSVYEP",
-        "hostedZoneName": "qlibin.com",
-        "domainName": "tg.qlibin.com"
+        }
       }
     },
     "defaultEnvironment": "dev"


### PR DESCRIPTION
## Summary

Closes #49

- Remove hardcoded AWS Account ID, Certificate ARN, Hosted Zone ID, zone name, and domain name from `cdk.json`
- Refactor CDK entrypoint to read these values from `process.env` instead of CDK context
- Update CI/CD workflows to pass values from GitHub Actions Variables

## Pre-merge checklist

Before this PR can pass CI, the following **GitHub Variables** must be set (Settings > Secrets and variables > Actions > Variables):

- `CERTIFICATE_ARN`
- `HOSTED_ZONE_ID`
- `HOSTED_ZONE_NAME`
- `DOMAIN_NAME`

`AWS_ACCOUNT_ID` already exists — no change needed.

## Test plan

- [x] All 23 infrastructure tests pass (tests don't read cdk.json — unaffected)
- [x] All 33 contract tests pass
- [x] CDK synth produces both stacks with all env vars set
- [x] CDK synth produces only SQS stack without domain vars (graceful degradation)
- [x] Build, type-check, lint, format-check all pass
- [x] CI CDK diff shows zero infrastructure changes (validates no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)