### PR TITLE
refactor: open TaskTypeSchema for extensibility

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlibin/tg-assistant-contracts",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Shared message schemas and TypeScript types for tg-assistant SQS queues",
   "type": "module",
   "main": "dist/index.js",

--- a/contracts/src/schemas/common.ts
+++ b/contracts/src/schemas/common.ts
@@ -2,17 +2,14 @@ import { z } from "zod";
 
 export const SCHEMA_VERSION = "1.0.0" as const;
 
-export const TaskTypeSchema = z.enum([
-  "playwright-scraping",
-  "url-monitoring",
-  "web-automation",
-  "perplexity-summary",
-  "content-analysis",
-  "text-processing",
-  "scheduled-linkedin",
-  "scheduled-german",
-  "system-health",
-]);
+export const TaskTypeSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(
+    /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/,
+    "Task type must be kebab-case (e.g. 'web-scraping', 'text-processing')",
+  );
 
 export type TaskType = z.infer<typeof TaskTypeSchema>;
 

--- a/contracts/test/schemas.test.ts
+++ b/contracts/test/schemas.test.ts
@@ -86,8 +86,8 @@ describe("OrderMessageSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid taskType", () => {
-    const msg = { ...validOrderMessage(), taskType: "unknown-task" };
+  it("rejects invalid taskType format", () => {
+    const msg = { ...validOrderMessage(), taskType: "INVALID_TYPE" };
     const result = OrderMessageSchema.safeParse(msg);
     expect(result.success).toBe(false);
   });
@@ -260,22 +260,37 @@ describe("ResultMessageSchema", () => {
 });
 
 describe("shared enums", () => {
-  it("TaskTypeSchema accepts all 9 task types", () => {
-    const taskTypes = [
+  it("TaskTypeSchema accepts valid kebab-case task types", () => {
+    const validTypes = [
       "playwright-scraping",
       "url-monitoring",
       "web-automation",
-      "perplexity-summary",
-      "content-analysis",
       "text-processing",
-      "scheduled-linkedin",
-      "scheduled-german",
-      "system-health",
+      "pdf-generation",
+      "my-new-worker",
+      "simple",
+      "a1-b2-c3",
     ];
-    for (const taskType of taskTypes) {
+    for (const taskType of validTypes) {
       expect(TaskTypeSchema.safeParse(taskType).success).toBe(true);
     }
-    expect(TaskTypeSchema.options).toHaveLength(9);
+  });
+
+  it("TaskTypeSchema rejects invalid task types", () => {
+    const invalidTypes = [
+      "",
+      "UPPERCASE",
+      "camelCase",
+      "has spaces",
+      "has_underscores",
+      "-leading-dash",
+      "trailing-dash-",
+      "double--dash",
+      "123-starts-with-number",
+    ];
+    for (const taskType of invalidTypes) {
+      expect(TaskTypeSchema.safeParse(taskType).success).toBe(false);
+    }
   });
 
   it("PrioritySchema accepts all 4 priorities", () => {


### PR DESCRIPTION
## Summary
- Replace `TaskTypeSchema` closed enum (9 hardcoded values) with an open kebab-case string pattern (`z.string().regex(...)`)
- Workers self-select task types they handle — adding a new worker no longer requires a contracts release
- Update tests to validate format constraints instead of exhaustive enum membership

## Test plan
- [x] All 34 contract tests pass (100% coverage)
- [x] All 23 infrastructure tests pass
- [x] Pre-commit hooks pass (build, lint, format, type-check, tests for both packages)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)