### PR TITLE
fix(contracts): add ts-node as explicit devDependency

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -40,6 +40,7 @@
     "jest": "^30.2.0",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",
+    "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "zod-to-json-schema": "^3.24.0"


### PR DESCRIPTION
## Summary

- `ts-node` was present in `package-lock.json` but missing from `package.json`, causing drift between the two files
- When Dependabot regenerated the lockfile in #56, `ts-node` was dropped since it wasn't declared in `package.json`
- This broke the `validate-contracts` CI job: Jest requires `ts-node` to parse the TypeScript `jest.config.ts` config file

## Test plan

- [ ] CI `validate-contracts` job passes
- [ ] PR #56 can be rebased and its CI should also pass after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)