### PR TITLE
feat(contracts): add optional chatId to OrderMessage and ResultMessage (v2.1.0)

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qlibin/tg-assistant-contracts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Shared message schemas and TypeScript types for tg-assistant SQS queues",
   "type": "module",
   "main": "dist/index.js",

--- a/contracts/src/schemas/order-message.ts
+++ b/contracts/src/schemas/order-message.ts
@@ -20,6 +20,7 @@ export const OrderMessageSchema = z.object({
   payload: PayloadSchema,
   userId: z.string().min(1),
   timestamp: z.string().datetime(),
+  chatId: z.number().int().optional(),
   priority: PrioritySchema.optional(),
   retryCount: z.number().int().min(0).max(3).optional(),
   deduplicationId: z.string().max(128).optional(),

--- a/contracts/src/schemas/result-message.ts
+++ b/contracts/src/schemas/result-message.ts
@@ -50,6 +50,7 @@ export const ResultMessageSchema = z.object({
   processingTime: z.number(),
   timestamp: z.string().datetime(),
   userId: z.string().min(1),
+  chatId: z.number().int().optional(),
   followUpAction: FollowUpActionSchema.optional(),
   priority: PrioritySchema.optional(),
   retryCount: z.number().int().min(0).max(3).optional(),

--- a/contracts/test/schemas.test.ts
+++ b/contracts/test/schemas.test.ts
@@ -148,6 +148,28 @@ describe("OrderMessageSchema", () => {
     const result = OrderMessageSchema.safeParse(msg);
     expect(result.success).toBe(false);
   });
+
+  it("accepts chatId when provided", () => {
+    const msg = { ...validOrderMessage(), chatId: 123456789 };
+    const result = OrderMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.chatId).toBe(123456789);
+    }
+  });
+
+  it("accepts message without chatId (backward compatibility with 2.0.0)", () => {
+    const msg = validOrderMessage();
+    expect(msg).not.toHaveProperty("chatId");
+    const result = OrderMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-integer chatId", () => {
+    const msg = { ...validOrderMessage(), chatId: 12.5 };
+    const result = OrderMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("ResultMessageSchema", () => {
@@ -256,6 +278,28 @@ describe("ResultMessageSchema", () => {
     if (result.success) {
       expect(result.data.queueMetrics).not.toHaveProperty("extra");
     }
+  });
+
+  it("accepts chatId when provided", () => {
+    const msg = { ...validResultMessage(), chatId: 987654321 };
+    const result = ResultMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.chatId).toBe(987654321);
+    }
+  });
+
+  it("accepts message without chatId (backward compatibility with 2.0.0)", () => {
+    const msg = validResultMessage();
+    expect(msg).not.toHaveProperty("chatId");
+    const result = ResultMessageSchema.safeParse(msg);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-integer chatId", () => {
+    const msg = { ...validResultMessage(), chatId: 12.5 };
+    const result = ResultMessageSchema.safeParse(msg);
+    expect(result.success).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `chatId: z.number().int().optional()` to `OrderMessageSchema` and `ResultMessageSchema`
- Bumps `contracts/package.json` to `2.1.0`
- Adds tests for `chatId` acceptance, backward compatibility with 2.0.0 messages, and rejection of non-integer values

## Why
The E2E echo loop needs to carry the originating Telegram chat ID from the webhook through the worker to the feedback Lambda. Without this field, the feedback Lambda cannot know which chat to reply to.

`chatId` is optional so existing producers (scheduled jobs, internal triggers) that don't set it remain valid — no migration needed and `schemaVersion: "1.0.0"` is unchanged.

## Test plan
- [x] `npm run validate` passes (40 tests, 100% coverage)
- [x] Messages without `chatId` still validate (backward compat with 2.0.0)
- [x] Messages with `chatId` validate and preserve the value
- [x] Non-integer `chatId` is rejected

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)